### PR TITLE
Add per-search screenshots toggle

### DIFF
--- a/crawler/SCHEMA.sql
+++ b/crawler/SCHEMA.sql
@@ -3,6 +3,7 @@ CREATE TABLE public.searches (
     name text NOT NULL,
     url text NOT NULL,
     is_active boolean NOT NULL DEFAULT true,
+    screenshots_enabled boolean NOT NULL DEFAULT true,
     created_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/crawler/autoscout/spiders/search.py
+++ b/crawler/autoscout/spiders/search.py
@@ -39,7 +39,7 @@ class CarPageRequest(SeleniumBaseRequest):
                           errback=spider.handle_error,
                           wait_for_element='h1',
                           script=ACCEPT_COOKIES_AND_EXPAND_FIELDS,
-                          screenshot=True)
+                          screenshot=spider.screenshots_enabled)
         super().__init__(**kwargs)
 
 
@@ -47,11 +47,13 @@ class SearchSpider(Spider):
     name = 'search'
     allowed_domains = ['www.autoscout24.ch', 'autoscout24.ch']
 
-    def __init__(self, search_id: int | str, search_name: str, url: str, *args, **kwargs) -> None:
+    def __init__(self, search_id: int | str, search_name: str, url: str,
+                 screenshots_enabled: bool | str = True, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.search_id = int(search_id)
         self.search_name = search_name
         self.url = urlparse(url)
+        self.screenshots_enabled = screenshots_enabled if isinstance(screenshots_enabled, bool) else screenshots_enabled != 'false'
         self.failed_requests: list[dict[str, str | int]] = []
         self.total_car_count = 0
 

--- a/crawler/run-spiders.py
+++ b/crawler/run-spiders.py
@@ -102,12 +102,12 @@ def main() -> None:
 
     with psycopg.connect(os.environ['PGSQL_URL'], connect_timeout=1) as conn:
         with conn.cursor() as cur:
-            searches: list[tuple[int, str, str]] = cur.execute(
-                'SELECT id, name, url FROM searches WHERE is_active = true ORDER BY name'
+            searches: list[tuple[int, str, str, bool]] = cur.execute(
+                'SELECT id, name, url, screenshots_enabled FROM searches WHERE is_active = true ORDER BY name'
             ).fetchall()
 
     if id_filter is not None:
-        searches = [(sid, name, url) for sid, name, url in searches if sid in id_filter]
+        searches = [(sid, name, url, ss) for sid, name, url, ss in searches if sid in id_filter]
 
     if not searches:
         log.warning('No active searches found in database')
@@ -121,9 +121,10 @@ def main() -> None:
     @defer.inlineCallbacks
     def crawl_all():
         try:
-            for search_id, search_name, url in searches:
+            for search_id, search_name, url, screenshots_enabled in searches:
                 log.info('Running spider for search: %s (id=%d)', search_name, search_id)
-                yield runner.crawl(SearchSpider, search_id=search_id, search_name=search_name, url=url)
+                yield runner.crawl(SearchSpider, search_id=search_id, search_name=search_name, url=url,
+                                   screenshots_enabled=screenshots_enabled)
         except Exception:
             log.exception('Spider run failed')
         finally:

--- a/frontend/src/components/search-manager.js
+++ b/frontend/src/components/search-manager.js
@@ -8,7 +8,9 @@ import {
    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle
 } from '@/components/ui/alert-dialog'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { createSearch, deleteSearch, toggleSearchActive, updateSearch } from '@/lib/actions'
+import {
+   createSearch, deleteSearch, toggleSearchActive, toggleSearchScreenshots, updateSearch
+} from '@/lib/actions'
 
 
 function formatBytes(bytes) {
@@ -58,6 +60,7 @@ function SearchRow({ search }) {
       return result
    }, null)
    const [, submitToggle] = useActionState(toggleSearchActive, null)
+   const [, submitToggleScreenshots] = useActionState(toggleSearchScreenshots, null)
 
    const [dialogOpen, setDialogOpen] = useState(false)
    const [deleteInfo, setDeleteInfo] = useState(null)
@@ -95,10 +98,11 @@ function SearchRow({ search }) {
    if (editing) {
       return (
          <tr className="border-b">
-            <td colSpan={8} className="p-2">
+            <td colSpan={9} className="p-2">
                <form action={submitUpdate} className="flex flex-col gap-2">
                   <input type="hidden" name="id" value={search.id} />
                   <input type="hidden" name="is_active" value={String(search.is_active)} />
+                  <input type="hidden" name="screenshots_enabled" value={String(search.screenshots_enabled)} />
                   <input
                      name="name"
                      defaultValue={search.name}
@@ -165,6 +169,23 @@ function SearchRow({ search }) {
                   title={search.is_active ? 'Active — click to deactivate' : 'Inactive — click to activate'}
                >
                   {search.is_active ? '✓' : ''}
+               </button>
+            </form>
+         </td>
+         <td className="p-2 text-center whitespace-nowrap">
+            <form action={submitToggleScreenshots} className="inline">
+               <input type="hidden" name="id" value={search.id} />
+               <input type="hidden" name="screenshots_enabled" value={String(!search.screenshots_enabled)} />
+               <button
+                  type="submit"
+                  className={`inline-flex size-4 items-center justify-center rounded-sm border text-xs transition-colors ${
+                     search.screenshots_enabled
+                        ? 'border-primary bg-primary text-primary-foreground'
+                        : 'border-muted-foreground/30'
+                  }`}
+                  title={search.screenshots_enabled ? 'Screenshots on — click to disable' : 'Screenshots off — click to enable'}
+               >
+                  {search.screenshots_enabled ? '✓' : ''}
                </button>
             </form>
          </td>
@@ -264,6 +285,7 @@ export default function SearchManager({ searches }) {
                         <th className="p-2 text-right whitespace-nowrap">Cars</th>
                         <th className="p-2 text-right whitespace-nowrap">Screenshots</th>
                         <th className="p-2 text-center whitespace-nowrap">Active</th>
+                        <th className="p-2 text-center whitespace-nowrap">Screenshots</th>
                         <th className="p-2 text-center whitespace-nowrap">Actions</th>
                      </tr>
                   </thead>

--- a/frontend/src/components/search-manager.js
+++ b/frontend/src/components/search-manager.js
@@ -285,7 +285,7 @@ export default function SearchManager({ searches }) {
                         <th className="p-2 text-right whitespace-nowrap">Cars</th>
                         <th className="p-2 text-right whitespace-nowrap">Screenshots</th>
                         <th className="p-2 text-center whitespace-nowrap">Active</th>
-                        <th className="p-2 text-center whitespace-nowrap">Screenshots</th>
+                        <th className="p-2 text-center whitespace-nowrap">Capture</th>
                         <th className="p-2 text-center whitespace-nowrap">Actions</th>
                      </tr>
                   </thead>

--- a/frontend/src/lib/actions.js
+++ b/frontend/src/lib/actions.js
@@ -35,6 +35,7 @@ export async function updateSearch(prevState, formData) {
    const name = formData.get('name')?.toString().trim()
    const url = formData.get('url')?.toString().trim()
    const isActive = formData.get('is_active') === 'true'
+   const screenshotsEnabled = formData.get('screenshots_enabled') === 'true'
 
    if (!name || !url) {
       return { error: 'Name and URL are required.' }
@@ -46,6 +47,7 @@ export async function updateSearch(prevState, formData) {
             set name = ${name},
                 url = ${url},
                 is_active = ${isActive},
+                screenshots_enabled = ${screenshotsEnabled},
                 updated_at = current_timestamp
           where id = ${id}`
       revalidatePath('/', 'layout')
@@ -120,6 +122,23 @@ export async function toggleSearchActive(prevState, formData) {
       await pgSql`
          update searches
             set is_active = ${isActive},
+                updated_at = current_timestamp
+          where id = ${id}`
+      revalidatePath('/', 'layout')
+      return { success: true }
+   } catch {
+      return { error: 'Failed to update search.' }
+   }
+}
+
+export async function toggleSearchScreenshots(prevState, formData) {
+   const id = parseInt(formData.get('id'), 10)
+   const screenshotsEnabled = formData.get('screenshots_enabled') === 'true'
+
+   try {
+      await pgSql`
+         update searches
+            set screenshots_enabled = ${screenshotsEnabled},
                 updated_at = current_timestamp
           where id = ${id}`
       revalidatePath('/', 'layout')


### PR DESCRIPTION
Screenshots are currently captured for every search with no way to opt out. This adds a `screenshots_enabled` boolean flag per search so users can disable screenshot capture on a search-by-search basis (useful for searches where screenshots are unnecessary or where storage cost matters).

## What changed

**DB schema** -- `searches` gets a new `screenshots_enabled boolean NOT NULL DEFAULT true` column. All existing searches keep screenshots enabled by default.

**Crawler** -- `run-spiders.py` fetches the new column and passes it to each spider. `SearchSpider` accepts `screenshots_enabled` (bool from the runner, or the string `'false'` when passed via the Scrapy CLI `-a` flag). `CarPageRequest` now sets `screenshot=spider.screenshots_enabled` instead of the hardcoded `True`, so Scrapy-SeleniumBase simply skips the capture when disabled -- no other pipeline changes needed since `ScreenshotPipeline` already handles a `None` screenshot gracefully.

**Frontend** -- `updateSearch` persists the new field; a new `toggleSearchScreenshots` server action mirrors `toggleSearchActive`. The search manager table gets a "Screenshots" toggle column (same checkbox-style button as "Active"), and the edit form passes `screenshots_enabled` through as a hidden field so it is preserved during name/URL edits.

## Migration required

Run the following on the live database before deploying the crawler:

```sql
ALTER TABLE searches ADD COLUMN screenshots_enabled boolean NOT NULL DEFAULT true;
```