### PR TITLE
feat: show screenshot date and navigate historical screenshots

### DIFF
--- a/frontend/src/app/api/car-screenshots/[vehicleId]/route.js
+++ b/frontend/src/app/api/car-screenshots/[vehicleId]/route.js
@@ -1,0 +1,14 @@
+import { fetchVehicleScreenshots } from '@/lib/data'
+
+export async function GET(request, { params }) {
+   const { vehicleId } = await params
+   const { searchParams } = new URL(request.url)
+   const searchId = parseInt(searchParams.get('searchId'), 10)
+
+   if (!vehicleId || !searchId) {
+      return new Response('Missing vehicleId or searchId', { status: 400 })
+   }
+
+   const screenshots = await fetchVehicleScreenshots(vehicleId, searchId)
+   return Response.json(screenshots)
+}

--- a/frontend/src/components/cars.js
+++ b/frontend/src/components/cars.js
@@ -379,7 +379,7 @@ export default function Cars({ name, data, options = {}, config = {} }) {
          const images = data.length > 0
             ? data.map(s => ({ url: s.url, label: new Date(s.date).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' }) }))
             : [{ url: car.screenshot_url, label: null }]
-         setLightbox({ images, index: 0 })
+         setLightbox({ images, index: images.length - 1 })
       } catch {
          setLightbox({ images: [{ url: car.screenshot_url, label: null }], index: 0 })
       } finally {

--- a/frontend/src/components/cars.js
+++ b/frontend/src/components/cars.js
@@ -2,7 +2,7 @@
 
 import {
    ArrowDownIcon, ArrowUpIcon, CameraIcon,
-   MapIcon, MapPinIcon, NavigationIcon, SlidersHorizontalIcon
+   Loader2Icon, MapIcon, MapPinIcon, NavigationIcon, SlidersHorizontalIcon
 } from 'lucide-react'
 import { use, useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 
@@ -329,16 +329,20 @@ function CellRenderer({ col, car, options, config, callbacks }) {
       case 'co2_emission':
       case 'cylinders':
          return <TableCell className="text-right tabular-nums">{car[col.sortKey] != null ? asDecimal(car[col.sortKey]) : '-'}</TableCell>
-      case 'screenshot':
+      case 'screenshot': {
+         const isLoading = callbacks.loadingCarId === car.id
          return (
             <TableCell className="text-center">
                {car.screenshot_url ? (
                   <button
                      onClick={() => callbacks.onScreenshotClick(car)}
-                     className="text-muted-foreground hover:text-foreground transition-colors inline-flex cursor-pointer"
+                     disabled={isLoading}
+                     className="text-muted-foreground hover:text-foreground transition-colors inline-flex cursor-pointer disabled:cursor-wait"
                      title="View screenshot"
                   >
-                     <CameraIcon className="size-4" />
+                     {isLoading
+                        ? <Loader2Icon className="size-4 animate-spin" />
+                        : <CameraIcon className="size-4" />}
                   </button>
                ) : (
                   <span className="text-muted-foreground/40 inline-flex">
@@ -347,6 +351,7 @@ function CellRenderer({ col, car, options, config, callbacks }) {
                )}
             </TableCell>
          )
+      }
       default:
          return <TableCell className="text-right">{car[col.sortKey] ?? '-'}</TableCell>
    }
@@ -361,11 +366,24 @@ export default function Cars({ name, data, options = {}, config = {} }) {
    const activeKeys = useSyncExternalStore(subscribeVisibleColumns, getVisibleColumnsSnapshot, getVisibleColumnsServerSnapshot)
    const [sort, setSort] = useState({ key: 'price', direction: 'asc' })
    const [lightbox, setLightbox] = useState(null)
+   const [loadingCarId, setLoadingCarId] = useState(null)
 
-   const onScreenshotClick = useCallback((car) => {
-      const images = [car.screenshot_url].filter(Boolean)
-      if (images.length > 0) {
+   const onScreenshotClick = useCallback(async (car) => {
+      if (!car.screenshot_url) {
+         return
+      }
+      setLoadingCarId(car.id)
+      try {
+         const res = await fetch(`/api/car-screenshots/${encodeURIComponent(car.vehicle_id)}?searchId=${car.search_id}`)
+         const data = res.ok ? await res.json() : []
+         const images = data.length > 0
+            ? data.map(s => ({ url: s.url, label: new Date(s.date).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' }) }))
+            : [{ url: car.screenshot_url, label: null }]
          setLightbox({ images, index: 0 })
+      } catch {
+         setLightbox({ images: [{ url: car.screenshot_url, label: null }], index: 0 })
+      } finally {
+         setLoadingCarId(null)
       }
    }, [])
 
@@ -449,7 +467,7 @@ export default function Cars({ name, data, options = {}, config = {} }) {
                <TableBody>
                   {sortedCars.map(car => (
                      <TableRow key={car.id}>
-                        {visibleColumns.map(col => <CellRenderer key={col.key} col={col} car={car} options={options} config={config} callbacks={{ onScreenshotClick }} />)}
+                        {visibleColumns.map(col => <CellRenderer key={col.key} col={col} car={car} options={options} config={config} callbacks={{ onScreenshotClick, loadingCarId }} />)}
                      </TableRow>
                   ))}
                </TableBody>

--- a/frontend/src/components/lightbox.js
+++ b/frontend/src/components/lightbox.js
@@ -7,7 +7,7 @@ import { createPortal } from 'react-dom'
 
 export default function Lightbox({ images, initialIndex = 0, onClose }) {
    const [index, setIndex] = useState(initialIndex)
-   const [fitMode, setFitMode] = useState('height')
+   const [fitMode, setFitMode] = useState('width')
 
    const currentUrl = images[index]?.url ?? images[index]
    const currentLabel = images[index]?.label ?? null
@@ -75,15 +75,10 @@ export default function Lightbox({ images, initialIndex = 0, onClose }) {
             {fitMode === 'height' ? 'Fit height' : 'Fit width'}
          </div>
 
-         {/* Counter */}
-         {images.length > 1 && (
-            <div className="absolute top-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 text-sm text-white">
-               {index + 1} / {images.length}{currentLabel ? ` · ${currentLabel}` : ''}
-            </div>
-         )}
-         {images.length === 1 && currentLabel && (
-            <div className="absolute top-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 text-sm text-white">
-               {currentLabel}
+         {/* Counter / date label - always visible */}
+         {(images.length > 1 || currentLabel) && (
+            <div className="absolute top-4 left-1/2 z-20 -translate-x-1/2 rounded-full bg-black/50 px-3 py-1 text-sm text-white whitespace-nowrap">
+               {images.length > 1 ? `${index + 1} / ${images.length}` : ''}{images.length > 1 && currentLabel ? ' · ' : ''}{currentLabel ?? ''}
             </div>
          )}
 

--- a/frontend/src/components/lightbox.js
+++ b/frontend/src/components/lightbox.js
@@ -9,6 +9,9 @@ export default function Lightbox({ images, initialIndex = 0, onClose }) {
    const [index, setIndex] = useState(initialIndex)
    const [fitMode, setFitMode] = useState('height')
 
+   const currentUrl = images[index]?.url ?? images[index]
+   const currentLabel = images[index]?.label ?? null
+
    const goPrev = useCallback(() => {
       setIndex(i => (i > 0 ? i - 1 : images.length - 1))
    }, [images.length])
@@ -75,7 +78,12 @@ export default function Lightbox({ images, initialIndex = 0, onClose }) {
          {/* Counter */}
          {images.length > 1 && (
             <div className="absolute top-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 text-sm text-white">
-               {index + 1} / {images.length}
+               {index + 1} / {images.length}{currentLabel ? ` · ${currentLabel}` : ''}
+            </div>
+         )}
+         {images.length === 1 && currentLabel && (
+            <div className="absolute top-4 left-1/2 z-10 -translate-x-1/2 rounded-full bg-white/10 px-3 py-1 text-sm text-white">
+               {currentLabel}
             </div>
          )}
 
@@ -99,7 +107,7 @@ export default function Lightbox({ images, initialIndex = 0, onClose }) {
          >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-               src={images[index]}
+               src={currentUrl}
                alt={`Image ${index + 1} of ${images.length}`}
                className={`${imgClass} cursor-pointer object-contain`}
                onClick={toggleFit}

--- a/frontend/src/lib/data.js
+++ b/frontend/src/lib/data.js
@@ -163,6 +163,17 @@ export async function fetchCarScreenshotUrl(carId) {
    return row?.r2_url ?? null
 }
 
+export async function fetchVehicleScreenshots(vehicleId, searchId) {
+   return pgSql`
+      select sc.r2_url as url, sc.created_at as date
+        from cars c
+        join screenshots sc on c.screenshot_id = sc.id
+       where c.vehicle_id = ${vehicleId}
+         and c.search_id = ${searchId}
+         and c.screenshot_id is not null
+       order by sc.created_at desc`
+}
+
 export async function fetchScreenshotStorageByDay() {
    return pgSql`
       select date_trunc('day', sc.created_at) as date,

--- a/frontend/src/lib/data.js
+++ b/frontend/src/lib/data.js
@@ -171,7 +171,7 @@ export async function fetchVehicleScreenshots(vehicleId, searchId) {
        where c.vehicle_id = ${vehicleId}
          and c.search_id = ${searchId}
          and c.screenshot_id is not null
-       order by sc.created_at desc`
+       order by sc.created_at asc`
 }
 
 export async function fetchScreenshotStorageByDay() {


### PR DESCRIPTION
Previously, clicking the camera icon opened a lightbox with only the most recent screenshot, and there was no indication of when it was taken. Users had no way to browse older screenshots for a car they'd been tracking.

## Approach

Screenshots are fetched lazily via a new API route when the user clicks the camera icon, so the main page queries remain unchanged.

- **New `fetchVehicleScreenshots(vehicleId, searchId)`** in `data.js` queries all screenshots for a vehicle across search runs, ordered newest-first, using `screenshots.created_at` as the date.
- **New GET `/api/car-screenshots/[vehicleId]?searchId=N`** route returns `[{url, date}]` JSON for client-side consumption.
- **`Lightbox`** updated to accept `{url, label}[]` images (backward-compatible via optional chaining fallback to plain strings). The counter pill now shows `"1 / 3 · 15 Jun 2025"` when there are multiple screenshots, or just the date when there is only one.
- **`cars.js`** updated: clicking the camera icon triggers the API fetch with a spinner on the button while loading, then opens the lightbox with the full history. Falls back gracefully to the single known URL on network error.