### PR TITLE
Split search page into tabbed sub-pages

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -121,6 +121,7 @@
     }
   body {
     @apply bg-background text-foreground;
+    scrollbar-gutter: stable;
     }
   html {
     @apply font-sans;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -121,10 +121,10 @@
     }
   body {
     @apply bg-background text-foreground;
-    scrollbar-gutter: stable;
     }
   html {
     @apply font-sans;
+    scrollbar-gutter: stable;
     }
 }
 

--- a/frontend/src/app/search/[searchName]/page.js
+++ b/frontend/src/app/search/[searchName]/page.js
@@ -3,34 +3,51 @@ import { Suspense } from 'react'
 import Cars from '@/components/cars'
 import DailyListingCount from '@/components/daily-listing-count'
 import MileagePriceComparison from '@/components/mileage-price-comparison'
+import SearchTabs from '@/components/search-tabs'
 import { fetchActiveListings, fetchConfig, fetchDailyListingCount, fetchPreviousListings } from '@/lib/data'
 
+const VALID_TABS = ['active', 'previous']
 
 export async function generateMetadata({ params }) {
    const { searchName } = await params
    return { title: `${decodeURIComponent(searchName)} – AutoScout24 Trends` }
 }
 
-export default async function Home({ params }) {
+export default async function Home({ params, searchParams }) {
 
    const awaitedParams = await params
    const searchName = decodeURIComponent(awaitedParams.searchName)
 
-   const activeListings = fetchActiveListings(searchName)
-   const previousListings = fetchPreviousListings(searchName)
-   const dailyListingCount = fetchDailyListingCount(searchName)
+   const { tab: tabParam } = await searchParams
+   const tab = VALID_TABS.includes(tabParam) ? tabParam : 'active'
+
    const config = await fetchConfig()
 
+   const activeListings = tab === 'active' ? fetchActiveListings(searchName) : null
+   const dailyListingCount = tab === 'active' ? fetchDailyListingCount(searchName) : null
+   const previousListings = tab === 'previous' ? fetchPreviousListings(searchName) : null
+
    return (
-      <Suspense fallback={<p className="text-sm text-muted-foreground">Loading data…</p>}>
-         <div className="flex gap-4">
-            <DailyListingCount data={dailyListingCount} />
-            <MileagePriceComparison data={activeListings} />
-         </div>
-         <div className="mt-4 flex flex-col gap-4">
-            <Cars name="Active listings" data={activeListings} config={config} />
-            <Cars name="Previous listings" data={previousListings} options={{ listingEnded: true }} config={config} />
-         </div>
-      </Suspense>
+      <>
+         <SearchTabs searchName={searchName} currentTab={tab} />
+         <Suspense fallback={<p className="mt-4 text-sm text-muted-foreground">Loading data…</p>}>
+            {tab === 'active' && (
+               <>
+                  <div className="mt-4 flex gap-4">
+                     <DailyListingCount data={dailyListingCount} />
+                     <MileagePriceComparison data={activeListings} />
+                  </div>
+                  <div className="mt-4">
+                     <Cars name="Active listings" data={activeListings} config={config} />
+                  </div>
+               </>
+            )}
+            {tab === 'previous' && (
+               <div className="mt-4">
+                  <Cars name="Previous listings" data={previousListings} options={{ listingEnded: true }} config={config} />
+               </div>
+            )}
+         </Suspense>
+      </>
    )
 }

--- a/frontend/src/components/navbar.js
+++ b/frontend/src/components/navbar.js
@@ -1,5 +1,6 @@
 import { ActivityIcon, SettingsIcon } from 'lucide-react'
 import Link from 'next/link'
+import { Suspense } from 'react'
 
 import SearchDropdown from '@/components/search-dropdown'
 import { fetchSearchNames } from '@/lib/data'
@@ -23,7 +24,9 @@ export default async function NavBar() {
                AutoScout24 Trends
             </Link>
             <nav className="flex items-center gap-4">
-               <SearchDropdown searches={searches} />
+               <Suspense fallback={null}>
+                  <SearchDropdown searches={searches} />
+               </Suspense>
                <Link
                   href="/search-runs"
                   aria-label="Search Runs"

--- a/frontend/src/components/search-dropdown.js
+++ b/frontend/src/components/search-dropdown.js
@@ -2,7 +2,7 @@
 
 import { ChevronDownIcon } from 'lucide-react'
 import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -16,10 +16,18 @@ import {
 export default function SearchDropdown({ searches }) {
 
    const pathname = usePathname()
+   const searchParams = useSearchParams()
+   const tab = searchParams.get('tab')
+
    const searchPrefix = '/search/'
    const activeSearch = pathname.startsWith(searchPrefix)
       ? decodeURIComponent(pathname.slice(searchPrefix.length))
       : null
+
+   function hrefFor(name) {
+      const base = `/search/${encodeURIComponent(name)}`
+      return tab ? `${base}?tab=${tab}` : base
+   }
 
    return (
       <DropdownMenu>
@@ -32,7 +40,7 @@ export default function SearchDropdown({ searches }) {
                {searches.map(search => (
                   <DropdownMenuItem
                      key={search.name}
-                     render={<Link href={`/search/${encodeURIComponent(search.name)}`} />}
+                     render={<Link href={hrefFor(search.name)} />}
                      className={activeSearch === search.name ? 'font-semibold text-foreground' : ''}
                   >
                      {search.name}

--- a/frontend/src/components/search-tabs.js
+++ b/frontend/src/components/search-tabs.js
@@ -1,0 +1,30 @@
+import Link from 'next/link'
+
+const TABS = [
+   { key: 'active', label: 'Active listings' },
+   { key: 'previous', label: 'Previous listings' },
+]
+
+export default function SearchTabs({ searchName, currentTab }) {
+   return (
+      <nav className="flex border-b">
+         {TABS.map(({ key, label }) => {
+            const isActive = currentTab === key
+            return (
+               <Link
+                  key={key}
+                  href={`/search/${encodeURIComponent(searchName)}?tab=${key}`}
+                  className={
+                     'px-4 py-2 text-sm font-medium transition-colors ' +
+                     (isActive
+                        ? 'border-b-2 border-foreground text-foreground'
+                        : 'text-muted-foreground hover:text-foreground')
+                  }
+               >
+                  {label}
+               </Link>
+            )
+         })}
+      </nav>
+   )
+}


### PR DESCRIPTION
The search page previously rendered everything at once: two charts, the active listings table, and the previous/ended listings table. This made it hard to focus and will become unwieldy as more content is added.

This PR introduces URL-driven tab navigation via a `?tab=` query param, splitting the page into two focused sub-pages with a clear path for a 3rd tab in the future.

**What changed:**

- `search-tabs.js` (new) -- a link-based tab nav bar (`Active listings` / `Previous listings`). Each tab is a plain `Link` to `?tab=active` or `?tab=previous`, with the active tab indicated by a bottom border. The `TABS` array makes adding a future tab a one-liner.
- `page.js` -- now reads `searchParams.tab` (defaults to `active`), renders `SearchTabs`, and only fetches the data needed for the active tab. Chart data is skipped entirely when on the `previous` tab.

**Design notes:**

- Server-side tab detection -- no client JS needed, URLs are shareable and bookmarkable.
- `active` is the default tab when no param is present, preserving the existing entry-point behavior.
- Data fetching is conditional per tab, so inactive tab data is never fetched.