### PR TITLE
Add price history tab

### DIFF
--- a/frontend/src/app/search/[searchName]/page.js
+++ b/frontend/src/app/search/[searchName]/page.js
@@ -3,10 +3,11 @@ import { Suspense } from 'react'
 import Cars from '@/components/cars'
 import DailyListingCount from '@/components/daily-listing-count'
 import MileagePriceComparison from '@/components/mileage-price-comparison'
+import PriceHistory from '@/components/price-history'
 import SearchTabs from '@/components/search-tabs'
-import { fetchActiveListings, fetchConfig, fetchDailyListingCount, fetchPreviousListings } from '@/lib/data'
+import { fetchActiveListings, fetchConfig, fetchDailyListingCount, fetchPreviousListings, fetchPriceChangedListings } from '@/lib/data'
 
-const VALID_TABS = ['active', 'previous']
+const VALID_TABS = ['active', 'previous', 'history']
 
 export async function generateMetadata({ params }) {
    const { searchName } = await params
@@ -26,6 +27,7 @@ export default async function Home({ params, searchParams }) {
    const activeListings = tab === 'active' ? fetchActiveListings(searchName) : null
    const dailyListingCount = tab === 'active' ? fetchDailyListingCount(searchName) : null
    const previousListings = tab === 'previous' ? fetchPreviousListings(searchName) : null
+   const priceChangedListings = tab === 'history' ? fetchPriceChangedListings(searchName) : null
 
    return (
       <>
@@ -45,6 +47,11 @@ export default async function Home({ params, searchParams }) {
             {tab === 'previous' && (
                <div className="mt-4">
                   <Cars name="Previous listings" data={previousListings} options={{ listingEnded: true }} config={config} />
+               </div>
+            )}
+            {tab === 'history' && (
+               <div className="mt-4">
+                  <PriceHistory data={priceChangedListings} />
                </div>
             )}
          </Suspense>

--- a/frontend/src/components/price-history.js
+++ b/frontend/src/components/price-history.js
@@ -1,21 +1,20 @@
 'use client'
 
-import { ArrowDownIcon, ArrowRightIcon, ArrowUpIcon } from 'lucide-react'
+import { ArrowDownIcon, ArrowUpIcon } from 'lucide-react'
 import { use, useMemo, useState } from 'react'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import {
    Table, TableBody, TableCell, TableHead, TableHeader, TableRow
 } from '@/components/ui/table'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useFormatter } from '@/lib/formatter-context'
 
 
 // --- Sorting ---
 
-function compareRows(a, b, key, direction) {
-   let valA = a[key]
-   let valB = b[key]
+function compareRows(a, b, col, direction) {
+   let valA = a[col.sortKey]
+   let valB = b[col.sortKey]
 
    const nullA = valA == null
    const nullB = valB == null
@@ -30,9 +29,9 @@ function compareRows(a, b, key, direction) {
    }
 
    let result
-   if (key === 'last_change_date') {
+   if (col.sortType === 'date') {
       result = new Date(valA) - new Date(valB)
-   } else if (key === 'title') {
+   } else if (col.sortType === 'text') {
       result = String(valA).localeCompare(String(valB))
    } else {
       result = Number(valA) - Number(valB)
@@ -41,46 +40,99 @@ function compareRows(a, b, key, direction) {
 }
 
 const COLUMNS = [
-   { key: 'title', label: 'Title', align: 'left' },
-   { key: 'first_price', label: 'First price', align: 'right' },
-   { key: 'price', label: 'Current price', align: 'right' },
-   { key: 'change_abs', label: 'Change', align: 'right' },
-   { key: 'change_count', label: '# Changes', align: 'right' },
-   { key: 'last_change_date', label: 'Last change', align: 'right' },
-   { key: 'history', label: 'History', align: 'left', noSort: true },
+   { key: 'title',          label: 'Title',        align: 'left',   sortKey: 'title',                  sortType: 'text' },
+   { key: 'year',           label: 'Year',         align: 'right',  sortKey: 'first_registration_date', sortType: 'date' },
+   { key: 'mileage',        label: 'Mileage',      align: 'right',  sortKey: 'mileage',                sortType: 'numeric' },
+   { key: 'price',          label: 'Price',        align: 'right',  sortKey: 'price',                  sortType: 'numeric' },
+   { key: 'change_abs',     label: 'Change',       align: 'right',  sortKey: 'change_pct',             sortType: 'numeric' },
+   { key: 'change_count',   label: '# Changes',   align: 'right',  sortKey: 'change_count',           sortType: 'numeric' },
+   { key: 'last_change',    label: 'Last change',  align: 'right',  sortKey: 'last_change_date',       sortType: 'date' },
+   { key: 'listed_since',   label: 'Listed since', align: 'right',  sortKey: 'created_date',           sortType: 'date' },
+   { key: 'seller',         label: 'Seller',       align: 'right',  sortKey: 'seller_name',            sortType: 'text' },
+   { key: 'is_active',      label: 'Active',       align: 'center', sortKey: 'is_active',              sortType: 'numeric' },
+   { key: 'history',        label: 'History',      align: 'left',   noSort: true },
 ]
-
-
-// --- Price badge ---
-
-function PriceBadge({ entry, formatter }) {
-   return (
-      <Tooltip delay={200}>
-         <TooltipTrigger className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-xs tabular-nums font-medium cursor-default">
-            {formatter.asDecimal(entry.price)}
-         </TooltipTrigger>
-         <TooltipContent side="bottom">
-            {formatter.asMediumDate(new Date(entry.date))}
-         </TooltipContent>
-      </Tooltip>
-   )
-}
 
 
 // --- History cell ---
 
 function HistoryCell({ history, formatter }) {
    return (
-      <div className="flex flex-wrap items-center gap-1">
+      <div className="space-y-0.5 text-xs tabular-nums">
          {history.map((entry, i) => (
-            <span key={i} className="inline-flex items-center gap-1">
-               <PriceBadge entry={entry} formatter={formatter} />
-               {i < history.length - 1 && (
-                  <ArrowRightIcon className="size-3 text-muted-foreground shrink-0" />
-               )}
-            </span>
+            <div key={i} className="flex gap-1.5 whitespace-nowrap">
+               <span className="text-muted-foreground">{formatter.asMediumDate(new Date(entry.date))}:</span>
+               <span className="font-medium">{formatter.asDecimal(entry.price)}</span>
+            </div>
          ))}
       </div>
+   )
+}
+
+
+// --- Row renderer ---
+
+function PriceHistoryRow({ row, formatter }) {
+   const isDown = row.change_abs < 0
+   const isUp = row.change_abs > 0
+   const changeColor = isDown
+      ? 'text-green-600 dark:text-green-400'
+      : isUp
+         ? 'text-red-600 dark:text-red-400'
+         : 'text-muted-foreground'
+   const changeSign = isUp ? '+' : ''
+
+   return (
+      <TableRow>
+         <TableCell>
+            <a
+               href={row.url}
+               target="_blank"
+               rel="noopener noreferrer"
+               className="hover:underline line-clamp-1 max-w-72 block"
+               title={row.title}
+            >
+               {row.title}
+            </a>
+         </TableCell>
+         <TableCell className="text-right tabular-nums">
+            {row.first_registration_date ? formatter.asShortDate(row.first_registration_date) : '-'}
+         </TableCell>
+         <TableCell className="text-right tabular-nums">
+            {row.mileage != null ? formatter.asDecimal(row.mileage) : '-'}
+         </TableCell>
+         <TableCell className="text-right tabular-nums font-medium">
+            {formatter.asDecimal(row.price)}
+         </TableCell>
+         <TableCell className={`text-right tabular-nums ${changeColor}`}>
+            <span className="block">{changeSign}{formatter.asDecimal(row.change_abs)}</span>
+            {row.change_pct != null && (
+               <span className="block text-xs">{changeSign}{row.change_pct.toFixed(1)}%</span>
+            )}
+         </TableCell>
+         <TableCell className="text-right tabular-nums">{row.change_count}</TableCell>
+         <TableCell className="text-right tabular-nums text-muted-foreground text-sm">
+            {formatter.asMediumDate(new Date(row.last_change_date))}
+         </TableCell>
+         <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
+            {row.created_date ? formatter.asMediumDate(new Date(row.created_date)) : '-'}
+         </TableCell>
+         <TableCell className="text-right text-sm">
+            <div>{row.seller_name ?? '-'}</div>
+            {(row.zip_code || row.city) && (
+               <div className="text-muted-foreground text-xs">{row.zip_code} {row.city}</div>
+            )}
+         </TableCell>
+         <TableCell className="text-center">
+            <span
+               className={`inline-block size-2 rounded-full ${row.is_active ? 'bg-green-500' : 'bg-muted-foreground/30'}`}
+               title={row.is_active ? 'Active' : 'Not active'}
+            />
+         </TableCell>
+         <TableCell>
+            <HistoryCell history={row.price_history} formatter={formatter} />
+         </TableCell>
+      </TableRow>
    )
 }
 
@@ -90,7 +142,7 @@ function HistoryCell({ history, formatter }) {
 export default function PriceHistory({ data }) {
    const rows = use(data)
    const formatter = useFormatter()
-   const [sort, setSort] = useState({ key: 'last_change_date', direction: 'desc' })
+   const [sort, setSort] = useState({ key: 'last_change', direction: 'desc' })
 
    const enriched = useMemo(() => rows.map(row => ({
       ...row,
@@ -100,7 +152,11 @@ export default function PriceHistory({ data }) {
    })), [rows])
 
    const sorted = useMemo(() => {
-      return [...enriched].sort((a, b) => compareRows(a, b, sort.key, sort.direction))
+      const col = COLUMNS.find(c => c.key === sort.key)
+      if (!col || col.noSort) {
+         return enriched
+      }
+      return [...enriched].sort((a, b) => compareRows(a, b, col, sort.direction))
    }, [enriched, sort])
 
    const handleSort = (key) => {
@@ -122,7 +178,7 @@ export default function PriceHistory({ data }) {
                      {COLUMNS.map(col => (
                         <TableHead
                            key={col.key}
-                           className={`${col.align === 'right' ? 'text-right' : ''} ${!col.noSort ? 'cursor-pointer hover:bg-muted/50' : ''} select-none transition-colors`}
+                           className={`${col.align === 'right' ? 'text-right' : col.align === 'center' ? 'text-center' : ''} ${!col.noSort ? 'cursor-pointer hover:bg-muted/50' : ''} select-none transition-colors`}
                            onClick={!col.noSort ? () => handleSort(col.key) : undefined}
                         >
                            <span className="inline-flex items-center gap-1">
@@ -138,55 +194,9 @@ export default function PriceHistory({ data }) {
                   </TableRow>
                </TableHeader>
                <TableBody>
-                  {sorted.map(row => {
-                     const isDown = row.change_abs < 0
-                     const isUp = row.change_abs > 0
-                     const changeColor = isDown
-                        ? 'text-green-600 dark:text-green-400'
-                        : isUp
-                           ? 'text-red-600 dark:text-red-400'
-                           : 'text-muted-foreground'
-                     const changeSign = isUp ? '+' : ''
-
-                     return (
-                        <TableRow key={row.vehicle_id}>
-                           <TableCell>
-                              <a
-                                 href={row.url}
-                                 target="_blank"
-                                 rel="noopener noreferrer"
-                                 className="hover:underline line-clamp-1 max-w-72 block"
-                                 title={row.title}
-                              >
-                                 {row.title}
-                              </a>
-                           </TableCell>
-                           <TableCell className="text-right tabular-nums text-muted-foreground">
-                              {formatter.asDecimal(row.first_price)}
-                           </TableCell>
-                           <TableCell className="text-right tabular-nums font-medium">
-                              {formatter.asDecimal(row.price)}
-                           </TableCell>
-                           <TableCell className={`text-right tabular-nums ${changeColor}`}>
-                              <span className="block">{changeSign}{formatter.asDecimal(row.change_abs)}</span>
-                              {row.change_pct != null && (
-                                 <span className="block text-xs">
-                                    {changeSign}{row.change_pct.toFixed(1)}%
-                                 </span>
-                              )}
-                           </TableCell>
-                           <TableCell className="text-right tabular-nums">
-                              {row.change_count}
-                           </TableCell>
-                           <TableCell className="text-right tabular-nums text-muted-foreground text-sm">
-                              {formatter.asMediumDate(new Date(row.last_change_date))}
-                           </TableCell>
-                           <TableCell>
-                              <HistoryCell history={row.price_history} formatter={formatter} />
-                           </TableCell>
-                        </TableRow>
-                     )
-                  })}
+                  {sorted.map(row => (
+                     <PriceHistoryRow key={row.vehicle_id} row={row} formatter={formatter} />
+                  ))}
                </TableBody>
             </Table>
          </CardContent>

--- a/frontend/src/components/price-history.js
+++ b/frontend/src/components/price-history.js
@@ -40,17 +40,17 @@ function compareRows(a, b, col, direction) {
 }
 
 const COLUMNS = [
-   { key: 'title',          label: 'Title',        align: 'left',   sortKey: 'title',                  sortType: 'text' },
+   { key: 'title',          label: 'Title',        align: 'left',   sortKey: 'title',                   sortType: 'text' },
+   { key: 'seller',         label: 'Seller',       align: 'right',  sortKey: 'seller_name',             sortType: 'text' },
    { key: 'year',           label: 'Year',         align: 'right',  sortKey: 'first_registration_date', sortType: 'date' },
-   { key: 'mileage',        label: 'Mileage',      align: 'right',  sortKey: 'mileage',                sortType: 'numeric' },
-   { key: 'price',          label: 'Price',        align: 'right',  sortKey: 'price',                  sortType: 'numeric' },
-   { key: 'change_abs',     label: 'Change',       align: 'right',  sortKey: 'change_pct',             sortType: 'numeric' },
-   { key: 'change_count',   label: '# Changes',   align: 'right',  sortKey: 'change_count',           sortType: 'numeric' },
-   { key: 'last_change',    label: 'Last change',  align: 'right',  sortKey: 'last_change_date',       sortType: 'date' },
-   { key: 'listed_since',   label: 'Listed since', align: 'right',  sortKey: 'created_date',           sortType: 'date' },
-   { key: 'seller',         label: 'Seller',       align: 'right',  sortKey: 'seller_name',            sortType: 'text' },
-   { key: 'is_active',      label: 'Active',       align: 'center', sortKey: 'is_active',              sortType: 'numeric' },
+   { key: 'mileage',        label: 'Mileage',      align: 'right',  sortKey: 'mileage',                 sortType: 'numeric' },
+   { key: 'price',          label: 'Price',        align: 'right',  sortKey: 'price',                   sortType: 'numeric' },
+   { key: 'change_abs',     label: 'Change',       align: 'right',  sortKey: 'change_pct',              sortType: 'numeric' },
+   { key: 'change_count',   label: '# Changes',    align: 'right',  sortKey: 'change_count',            sortType: 'numeric' },
    { key: 'history',        label: 'History',      align: 'left',   noSort: true },
+   { key: 'listed_since',   label: 'Listed since', align: 'right',  sortKey: 'created_date',            sortType: 'date' },
+   { key: 'last_change',    label: 'Last change',  align: 'right',  sortKey: 'last_change_date',        sortType: 'date' },
+   { key: 'is_active',      label: 'Active',       align: 'center', sortKey: 'is_active',               sortType: 'numeric' },
 ]
 
 
@@ -58,13 +58,25 @@ const COLUMNS = [
 
 function HistoryCell({ history, formatter }) {
    return (
-      <div className="space-y-0.5 text-xs tabular-nums">
-         {history.map((entry, i) => (
-            <div key={i} className="flex gap-1.5 whitespace-nowrap">
-               <span className="text-muted-foreground">{formatter.asMediumDate(new Date(entry.date))}:</span>
-               <span className="font-medium">{formatter.asDecimal(entry.price)}</span>
-            </div>
-         ))}
+      <div className="space-y-0.5 tabular-nums">
+         {history.map((entry, i) => {
+            const prev = history[i - 1]
+            const delta = prev != null ? entry.price - prev.price : null
+            const deltaPct = prev != null && prev.price ? (delta / prev.price) * 100 : null
+            const deltaSign = delta > 0 ? '+' : ''
+            const deltaColor = delta < 0 ? 'text-green-600 dark:text-green-400' : delta > 0 ? 'text-red-600 dark:text-red-400' : 'text-muted-foreground'
+            return (
+               <div key={i} className="flex gap-1.5 whitespace-nowrap items-baseline">
+                  <span className="text-muted-foreground text-xs">{formatter.asMediumDate(new Date(entry.date))}:</span>
+                  <span className="font-medium">{formatter.asDecimal(entry.price)}</span>
+                  {delta != null && (
+                     <span className={`text-xs ${deltaColor}`}>
+                        {deltaSign}{formatter.asDecimal(delta)}{deltaPct != null ? ` (${deltaSign}${deltaPct.toFixed(1)}%)` : ''}
+                     </span>
+                  )}
+               </div>
+            )
+         })}
       </div>
    )
 }
@@ -84,6 +96,7 @@ function PriceHistoryRow({ row, formatter }) {
 
    return (
       <TableRow>
+         {/* title */}
          <TableCell>
             <a
                href={row.url}
@@ -95,42 +108,52 @@ function PriceHistoryRow({ row, formatter }) {
                {row.title}
             </a>
          </TableCell>
+         {/* seller */}
+         <TableCell className="text-right">
+            <div>{row.seller_name ?? '-'}</div>
+            {(row.zip_code || row.city) && (
+               <div className="text-muted-foreground text-xs">{row.zip_code} {row.city}</div>
+            )}
+         </TableCell>
+         {/* year */}
          <TableCell className="text-right tabular-nums">
             {row.first_registration_date ? formatter.asShortDate(row.first_registration_date) : '-'}
          </TableCell>
+         {/* mileage */}
          <TableCell className="text-right tabular-nums">
             {row.mileage != null ? formatter.asDecimal(row.mileage) : '-'}
          </TableCell>
+         {/* price */}
          <TableCell className="text-right tabular-nums font-medium">
             {formatter.asDecimal(row.price)}
          </TableCell>
+         {/* change */}
          <TableCell className={`text-right tabular-nums ${changeColor}`}>
             <span className="block">{changeSign}{formatter.asDecimal(row.change_abs)}</span>
             {row.change_pct != null && (
                <span className="block text-xs">{changeSign}{row.change_pct.toFixed(1)}%</span>
             )}
          </TableCell>
+         {/* # changes */}
          <TableCell className="text-right tabular-nums">{row.change_count}</TableCell>
+         {/* history */}
+         <TableCell>
+            <HistoryCell history={row.price_history} formatter={formatter} />
+         </TableCell>
+         {/* listed since */}
+         <TableCell className="text-right tabular-nums text-muted-foreground text-sm">
+            {row.created_date ? formatter.asMediumDate(new Date(row.created_date)) : '-'}
+         </TableCell>
+         {/* last change */}
          <TableCell className="text-right tabular-nums text-muted-foreground text-sm">
             {formatter.asMediumDate(new Date(row.last_change_date))}
          </TableCell>
-         <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
-            {row.created_date ? formatter.asMediumDate(new Date(row.created_date)) : '-'}
-         </TableCell>
-         <TableCell className="text-right text-sm">
-            <div>{row.seller_name ?? '-'}</div>
-            {(row.zip_code || row.city) && (
-               <div className="text-muted-foreground text-xs">{row.zip_code} {row.city}</div>
-            )}
-         </TableCell>
+         {/* active */}
          <TableCell className="text-center">
             <span
                className={`inline-block size-2 rounded-full ${row.is_active ? 'bg-green-500' : 'bg-muted-foreground/30'}`}
                title={row.is_active ? 'Active' : 'Not active'}
             />
-         </TableCell>
-         <TableCell>
-            <HistoryCell history={row.price_history} formatter={formatter} />
          </TableCell>
       </TableRow>
    )

--- a/frontend/src/components/price-history.js
+++ b/frontend/src/components/price-history.js
@@ -46,7 +46,6 @@ const COLUMNS = [
    { key: 'mileage',        label: 'Mileage',      align: 'right',  sortKey: 'mileage',                 sortType: 'numeric' },
    { key: 'price',          label: 'Price',        align: 'right',  sortKey: 'price',                   sortType: 'numeric' },
    { key: 'change_abs',     label: 'Change',       align: 'right',  sortKey: 'change_pct',              sortType: 'numeric' },
-   { key: 'change_count',   label: '# Changes',    align: 'right',  sortKey: 'change_count',            sortType: 'numeric' },
    { key: 'history',        label: 'History',      align: 'left',   noSort: true },
    { key: 'listed_since',   label: 'Listed since', align: 'right',  sortKey: 'created_date',            sortType: 'date' },
    { key: 'last_change',    label: 'Last change',  align: 'right',  sortKey: 'last_change_date',        sortType: 'date' },
@@ -134,8 +133,6 @@ function PriceHistoryRow({ row, formatter }) {
                <span className="block text-xs">{changeSign}{row.change_pct.toFixed(1)}%</span>
             )}
          </TableCell>
-         {/* # changes */}
-         <TableCell className="text-right tabular-nums">{row.change_count}</TableCell>
          {/* history */}
          <TableCell>
             <HistoryCell history={row.price_history} formatter={formatter} />

--- a/frontend/src/components/price-history.js
+++ b/frontend/src/components/price-history.js
@@ -1,0 +1,195 @@
+'use client'
+
+import { ArrowDownIcon, ArrowRightIcon, ArrowUpIcon } from 'lucide-react'
+import { use, useMemo, useState } from 'react'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+   Table, TableBody, TableCell, TableHead, TableHeader, TableRow
+} from '@/components/ui/table'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useFormatter } from '@/lib/formatter-context'
+
+
+// --- Sorting ---
+
+function compareRows(a, b, key, direction) {
+   let valA = a[key]
+   let valB = b[key]
+
+   const nullA = valA == null
+   const nullB = valB == null
+   if (nullA && nullB) {
+      return 0
+   }
+   if (nullA) {
+      return 1
+   }
+   if (nullB) {
+      return -1
+   }
+
+   let result
+   if (key === 'last_change_date') {
+      result = new Date(valA) - new Date(valB)
+   } else if (key === 'title') {
+      result = String(valA).localeCompare(String(valB))
+   } else {
+      result = Number(valA) - Number(valB)
+   }
+   return direction === 'asc' ? result : -result
+}
+
+const COLUMNS = [
+   { key: 'title', label: 'Title', align: 'left' },
+   { key: 'first_price', label: 'First price', align: 'right' },
+   { key: 'price', label: 'Current price', align: 'right' },
+   { key: 'change_abs', label: 'Change', align: 'right' },
+   { key: 'change_count', label: '# Changes', align: 'right' },
+   { key: 'last_change_date', label: 'Last change', align: 'right' },
+   { key: 'history', label: 'History', align: 'left', noSort: true },
+]
+
+
+// --- Price badge ---
+
+function PriceBadge({ entry, formatter }) {
+   return (
+      <Tooltip delay={200}>
+         <TooltipTrigger className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-xs tabular-nums font-medium cursor-default">
+            {formatter.asDecimal(entry.price)}
+         </TooltipTrigger>
+         <TooltipContent side="bottom">
+            {formatter.asMediumDate(new Date(entry.date))}
+         </TooltipContent>
+      </Tooltip>
+   )
+}
+
+
+// --- History cell ---
+
+function HistoryCell({ history, formatter }) {
+   return (
+      <div className="flex flex-wrap items-center gap-1">
+         {history.map((entry, i) => (
+            <span key={i} className="inline-flex items-center gap-1">
+               <PriceBadge entry={entry} formatter={formatter} />
+               {i < history.length - 1 && (
+                  <ArrowRightIcon className="size-3 text-muted-foreground shrink-0" />
+               )}
+            </span>
+         ))}
+      </div>
+   )
+}
+
+
+// --- Main component ---
+
+export default function PriceHistory({ data }) {
+   const rows = use(data)
+   const formatter = useFormatter()
+   const [sort, setSort] = useState({ key: 'last_change_date', direction: 'desc' })
+
+   const enriched = useMemo(() => rows.map(row => ({
+      ...row,
+      change_abs: row.price - row.first_price,
+      change_pct: row.first_price ? ((row.price - row.first_price) / row.first_price) * 100 : null,
+      change_count: Array.isArray(row.price_history) ? row.price_history.length - 1 : 0,
+   })), [rows])
+
+   const sorted = useMemo(() => {
+      return [...enriched].sort((a, b) => compareRows(a, b, sort.key, sort.direction))
+   }, [enriched, sort])
+
+   const handleSort = (key) => {
+      setSort(prev => ({
+         key,
+         direction: prev.key === key && prev.direction === 'asc' ? 'desc' : 'asc',
+      }))
+   }
+
+   return (
+      <Card>
+         <CardHeader>
+            <CardTitle>Price history: {rows.length} car{rows.length !== 1 ? 's' : ''} with price changes</CardTitle>
+         </CardHeader>
+         <CardContent className="px-0">
+            <Table>
+               <TableHeader>
+                  <TableRow>
+                     {COLUMNS.map(col => (
+                        <TableHead
+                           key={col.key}
+                           className={`${col.align === 'right' ? 'text-right' : ''} ${!col.noSort ? 'cursor-pointer hover:bg-muted/50' : ''} select-none transition-colors`}
+                           onClick={!col.noSort ? () => handleSort(col.key) : undefined}
+                        >
+                           <span className="inline-flex items-center gap-1">
+                              {col.label}
+                              {!col.noSort && sort.key === col.key && (
+                                 sort.direction === 'asc'
+                                    ? <ArrowUpIcon className="size-3" />
+                                    : <ArrowDownIcon className="size-3" />
+                              )}
+                           </span>
+                        </TableHead>
+                     ))}
+                  </TableRow>
+               </TableHeader>
+               <TableBody>
+                  {sorted.map(row => {
+                     const isDown = row.change_abs < 0
+                     const isUp = row.change_abs > 0
+                     const changeColor = isDown
+                        ? 'text-green-600 dark:text-green-400'
+                        : isUp
+                           ? 'text-red-600 dark:text-red-400'
+                           : 'text-muted-foreground'
+                     const changeSign = isUp ? '+' : ''
+
+                     return (
+                        <TableRow key={row.vehicle_id}>
+                           <TableCell>
+                              <a
+                                 href={row.url}
+                                 target="_blank"
+                                 rel="noopener noreferrer"
+                                 className="hover:underline line-clamp-1 max-w-72 block"
+                                 title={row.title}
+                              >
+                                 {row.title}
+                              </a>
+                           </TableCell>
+                           <TableCell className="text-right tabular-nums text-muted-foreground">
+                              {formatter.asDecimal(row.first_price)}
+                           </TableCell>
+                           <TableCell className="text-right tabular-nums font-medium">
+                              {formatter.asDecimal(row.price)}
+                           </TableCell>
+                           <TableCell className={`text-right tabular-nums ${changeColor}`}>
+                              <span className="block">{changeSign}{formatter.asDecimal(row.change_abs)}</span>
+                              {row.change_pct != null && (
+                                 <span className="block text-xs">
+                                    {changeSign}{row.change_pct.toFixed(1)}%
+                                 </span>
+                              )}
+                           </TableCell>
+                           <TableCell className="text-right tabular-nums">
+                              {row.change_count}
+                           </TableCell>
+                           <TableCell className="text-right tabular-nums text-muted-foreground text-sm">
+                              {formatter.asMediumDate(new Date(row.last_change_date))}
+                           </TableCell>
+                           <TableCell>
+                              <HistoryCell history={row.price_history} formatter={formatter} />
+                           </TableCell>
+                        </TableRow>
+                     )
+                  })}
+               </TableBody>
+            </Table>
+         </CardContent>
+      </Card>
+   )
+}

--- a/frontend/src/components/search-tabs.js
+++ b/frontend/src/components/search-tabs.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 const TABS = [
    { key: 'active', label: 'Active listings' },
    { key: 'previous', label: 'Previous listings' },
+   { key: 'history', label: 'Price history' },
 ]
 
 export default function SearchTabs({ searchName, currentTab }) {

--- a/frontend/src/lib/data.js
+++ b/frontend/src/lib/data.js
@@ -209,7 +209,13 @@ export async function fetchScreenshotStorageByDay() {
 
 export async function fetchPriceChangedListings(searchName) {
    return pgSql`
-      with ordered_prices as (
+      with latest_run as (
+         select max(c2.search_run_id) as id
+           from cars c2
+          inner join searches s2 on c2.search_id = s2.id
+          where s2.name = ${searchName}
+      ),
+      ordered_prices as (
          select c.vehicle_id, c.price, c.search_run_id, sr.started_at,
                 lag(c.price) over (partition by c.vehicle_id order by c.search_run_id) as prev_price
            from cars c
@@ -239,8 +245,13 @@ export async function fetchPriceChangedListings(searchName) {
       latest_car as (
          select distinct on (c.vehicle_id)
                 c.id, c.search_id, c.url, c.title, c.price, c.vehicle_id,
-                c.mileage, c.first_registration_date,
-                se.type seller_type, se.name seller_name, se.zip_code, se.city
+                c.mileage, c.first_registration_date, c.created_date,
+                se.type seller_type, se.name seller_name, se.zip_code, se.city,
+                exists(
+                   select 1 from cars ac
+                    where ac.vehicle_id = c.vehicle_id
+                      and ac.search_run_id = (select id from latest_run)
+                ) as is_active
            from cars c
           inner join searches s on c.search_id = s.id
           inner join sellers se on c.seller_id = se.id

--- a/frontend/src/lib/data.js
+++ b/frontend/src/lib/data.js
@@ -207,6 +207,57 @@ export async function fetchScreenshotStorageByDay() {
        order by date`
 }
 
+export async function fetchPriceChangedListings(searchName) {
+   return pgSql`
+      with ordered_prices as (
+         select c.vehicle_id, c.price, c.search_run_id, sr.started_at,
+                lag(c.price) over (partition by c.vehicle_id order by c.search_run_id) as prev_price
+           from cars c
+          inner join searches s on c.search_id = s.id
+          inner join search_runs sr on c.search_run_id = sr.id
+          where s.name = ${searchName}
+            and c.price is not null
+      ),
+      changed_vehicles as (
+         select distinct vehicle_id
+           from ordered_prices
+          where prev_price is not null and price != prev_price
+      ),
+      price_change_entries as (
+         select vehicle_id, price, started_at
+           from ordered_prices
+          where vehicle_id in (select vehicle_id from changed_vehicles)
+            and (prev_price is null or price != prev_price)
+      ),
+      price_history_agg as (
+         select vehicle_id,
+                json_agg(json_build_object('price', price, 'date', started_at) order by started_at asc) as price_history,
+                max(started_at) as last_change_date
+           from price_change_entries
+          group by vehicle_id
+      ),
+      latest_car as (
+         select distinct on (c.vehicle_id)
+                c.id, c.search_id, c.url, c.title, c.price, c.vehicle_id,
+                c.mileage, c.first_registration_date,
+                se.type seller_type, se.name seller_name, se.zip_code, se.city
+           from cars c
+          inner join searches s on c.search_id = s.id
+          inner join sellers se on c.seller_id = se.id
+          where s.name = ${searchName}
+            and c.vehicle_id in (select vehicle_id from changed_vehicles)
+            and c.price is not null
+          order by c.vehicle_id, c.search_run_id desc
+      )
+      select lc.*,
+             ph.price_history,
+             ph.last_change_date,
+             (ph.price_history->0->>'price')::int as first_price
+        from latest_car lc
+        join price_history_agg ph on lc.vehicle_id = ph.vehicle_id
+       order by ph.last_change_date desc`
+}
+
 export async function fetchScreenshotStorageSummary() {
    const [row] = await pgSql`
       select count(*)::int as total_count,


### PR DESCRIPTION
## Summary

Adds a third **"Price history"** tab to the search page, showing every vehicle whose price changed at least once across crawl runs — along with its full price change timeline.

## What's new

### SQL (`data.js`)
New `fetchPriceChangedListings(searchName)` query using:
- `LAG()` window function to detect consecutive price changes per `vehicle_id`
- `json_agg` to build a compact `price_history` array (one entry per change point, not per run)
- Returns latest car details + `first_price` + `last_change_date` for sorting

### UI
- **`search-tabs.js`** — "Price history" added as the third tab
- **`page.js`** — `'history'` added to `VALID_TABS`; data fetch and render wired in
- **`price-history.js`** (new) — client component with sortable table:

| Column | Notes |
|---|---|
| Title | Link to listing |
| First price | Price at first scrape |
| Current price | Price at latest scrape |
| Change | Absolute (CHF) + % delta, green/red colored |
| # Changes | Count of distinct price changes |
| Last change | Date of most recent price change |
| History | Inline sequence of price badges; hover each badge for the date |

Default sort: most recently changed listings first.